### PR TITLE
Update from upstream

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,9 @@ script:
   - ansible-lint tasks/main.yml
   - echo localhost > inventory
   - ansible-playbook -i inventory --syntax-check --list-tasks test/test.yml -e "role_name=ansible-role-nginx" -e "hosts_group=hosts_group"
-  - ansible-playbook -i inventory --connection=local --sudo -vvvv test/test.yml -u root -e "role_name=ansible-role-nginx" -e "hosts_group=localhost"
+  - ansible-playbook -i inventory --connection=local --become -vvvv test/test.yml -u root -e "role_name=ansible-role-nginx" -e "hosts_group=localhost"
   - >
-      ansible-playbook -i inventory --connection=local --sudo -vvvv test/test.yml -u root -e "role_name=ansible-role-nginx" -e "hosts_group=localhost"
+      ansible-playbook -i inventory --connection=local --become -vvvv test/test.yml -u root -e "role_name=ansible-role-nginx" -e "hosts_group=localhost"
       | grep -q 'changed=0.*failed=0'
       && (echo 'Idempotence test: pass' && exit 0)
       || (echo 'Idempotence test: fail' && exit 1)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 nginx
 =====
 
+## @jdauphant : This Role is community managed, I will not develop anymore myself on it but I can review and accept pull request (Reviewers on PR are welcomed too)
+
+
 This role installs and configures the nginx web server. The user can specify
 any http configuration parameters they wish to apply their site. Any number of
 sites can be added with configurations of your choice.

--- a/README.md
+++ b/README.md
@@ -103,6 +103,17 @@ nginx_set_real_ip_from_cloudflare: True
 nginx_amplify: true
 nginx_amplify_api_key: "your_api_key_goes_here"
 nginx_amplify_update_agent: true
+
+# Define modules (only for RHEL & CentOS).
+# available modules:.
+# - mod-http-geoip
+# - mod-http-image-filter
+# - mod-http-perl
+# - mod-http-xslt-filter
+# - mod-mail
+# - mod-stream
+nginx_module_configs:
+  - mod-http-geoip
 ```
 
 Examples

--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ Additional configurations are created in /etc/nginx/conf.d/
                proxy_set_header Host $myhost;
              }
 ```
-## 8) Example to use this role with my ssl-certs role to generate or copie ssl certificate ( https://galaxy.ansible.com/jdauphant/ssl-certs )
+## 8) Example to use this role with my ssl-certs role to generate or copy ssl certificate ( https://galaxy.ansible.com/jdauphant/ssl-certs )
 ```yaml
  - hosts: all
    roles:

--- a/README.md
+++ b/README.md
@@ -104,14 +104,36 @@ nginx_amplify: true
 nginx_amplify_api_key: "your_api_key_goes_here"
 nginx_amplify_update_agent: true
 
-# Define modules (only for RHEL & CentOS).
-# available modules:.
+# Define modules to enable in configuration
+#
+# Nginx installed via EPEL and APT repos will also install some modules automatically.
+# For official Nginx repo use you will need to install module packages manually.
+#
+# When using with EPEL and APT repos, specify this section as a list of configuration
+# file names, minus the .conf file name extension.
+
+# When using the official Nginx repo, specify this section as list of module file
+# names, minus the .so file name extension.
+#
+# Available module config files in EPEL and APT repos:
+# (APT actually has several more, see https://wiki.debian.org/Nginx/)
 # - mod-http-geoip
 # - mod-http-image-filter
 # - mod-http-perl
 # - mod-http-xslt-filter
 # - mod-mail
 # - mod-stream
+#
+# Available module filenames in Official NGINX repo:
+# - ngx_http_geoip_module
+# - ngx_http_image_filter_module
+# - ngx_http_perl_module
+# - ngx_http_xslt_filter_module
+# - ngx_http_js_module
+#
+# Custom compiled modules are ok too if the .so file exists in same location as a packaged module would be:
+# - ngx_http_modsecurity_module
+#
 nginx_module_configs:
   - mod-http-geoip
 ```

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -57,6 +57,7 @@ nginx_disabled_sites: []
 nginx_module_configs: []
 nginx_remove_modules: []
 nginx_disabled_modules: []
+nginx_modules_location: /usr/lib64/nginx/modules # For this variable, a specific value for the OS can be applied in vars/{{ ansible_os_family }}.
 
 nginx_configs: {}
 nginx_snippets: {}

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -54,6 +54,10 @@ nginx_sites:
 nginx_remove_sites: []
 nginx_disabled_sites: []
 
+nginx_module_configs: []
+nginx_remove_modules: []
+nginx_disabled_modules: []
+
 nginx_configs: {}
 nginx_snippets: {}
 nginx_stream_configs: {}

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -15,7 +15,7 @@
     - reload nginx - after config check
 
 - name: check nginx configuration
-  command: "{{ nginx_binary_name }} -t"
+  command: "{{ nginx_binary_name }} -t -c {{ nginx_conf_dir }}/nginx.conf"
   register: result
   changed_when: "result.rc != 0"
   check_mode: no

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,6 +1,7 @@
 ---
 galaxy_info:
   author: "DAUPHANT Julien"
+  description: Ansible role to install Nginx.
   license: BSD
   min_ansible_version: 2.4
   platforms:

--- a/tasks/amplify.yml
+++ b/tasks/amplify.yml
@@ -27,15 +27,19 @@
         path: "{{ nginx_amplify_script_path }}"
         state: absent
 
-  when: amplify_agent_installed.failed == true
+  when: amplify_agent_installed.failed|bool
   tags: [configuration, packages]
 
 - name: Update Amplify Agent if already installed and update flag is enabled
   package:
     name: nginx-amplify-agent
     state: latest
-  when: amplify_agent_installed.failed == false and nginx_amplify_update_agent == true
-  tags: [packages]
+  when:
+    - not amplify_agent_installed.failed|bool
+    - nginx_amplify_update_agent|bool
+  tags:
+    - packages
+    - skip_ansible_lint  # latest package version
 
 - name: Verify Amplify agent is up and running
   service:

--- a/tasks/amplify.yml
+++ b/tasks/amplify.yml
@@ -43,4 +43,3 @@
     state: started
     enabled: true
   tags: [service]
-

--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -11,10 +11,10 @@
   get_url:
     url: https://raw.githubusercontent.com/nginx/nginx/master/conf/mime.types
     dest: "{{ nginx_conf_dir }}/mime.types"
-  when: nginx_mime_types_file.stat.exists == False
+  when: not nginx_mime_types_file.stat.exists|bool
   notify:
     - reload nginx
-  
+
 - name: Copy the nginx configuration file
   template:
     src: nginx.conf.j2
@@ -75,7 +75,10 @@
     - reload nginx
   when: nginx_stream_params or nginx_stream_configs
 
-- name: Create configuration files in modules-available (only for nginx official repo or custom modules, Centos/RHEL/Debian/Ubuntu EPEL/APT repo packages have these config files already)
+- name: |
+    Create configuration files in modules-available (only for nginx official
+    repo or custom modules, Centos/RHEL/Debian/Ubuntu EPEL/APT repo packages
+    have these config files already)
   template:
     src: module.conf.j2
     dest: "{{ nginx_conf_dir }}/modules-available/{{ item }}.conf"

--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -62,11 +62,14 @@
 - name: Create links for modules-enabled
   file:
     state: link
-    src: "/urs/share/nginx/modules/{{ item }}.conf"
+    src: "/usr/share/nginx/modules/{{ item }}.conf"
     dest: "{{ nginx_conf_dir }}/modules-enabled/{{ item }}.conf"
   with_items: "{{ nginx_module_configs }}"
-  when: (item not in nginx_remove_modules) and (item not in nginx_disabled_modules)
   ignore_errors: "{{ ansible_check_mode }}"
   notify:
     - reload nginx
-  when: ansible_distribution == 'CentOS' or ansible_distribution == 'Red Hat Enterprise Linux'
+  when:
+    - (item not in nginx_remove_modules) and (item not in nginx_disabled_modules)
+    - ansible_distribution == 'CentOS' or ansible_distribution == 'Red Hat Enterprise Linux'
+    - nginx_install_epel_repo
+

--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -1,4 +1,20 @@
 ---
+
+- name: Check if nginx mime.types file exists
+  stat:
+    path: "{{ nginx_conf_dir }}/mime.types"
+  register: nginx_mime_types_file
+  notify:
+    - reload nginx
+
+- name: Ensure mime.types file exists if it was missing
+  get_url:
+    url: https://raw.githubusercontent.com/nginx/nginx/master/conf/mime.types
+    dest: "{{ nginx_conf_dir }}/mime.types"
+  when: nginx_mime_types_file.stat.exists == False
+  notify:
+    - reload nginx
+  
 - name: Copy the nginx configuration file
   template:
     src: nginx.conf.j2
@@ -122,4 +138,3 @@
   ignore_errors: "{{ ansible_check_mode }}"
   notify:
     - reload nginx
-

--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -58,3 +58,22 @@
   notify:
     - reload nginx
   when: nginx_stream_params or nginx_stream_configs
+
+- name: Create configuration for modules
+  template:
+    src: module.conf.j2
+    dest: "{{ nginx_conf_dir }}/modules-available/{{ item }}.conf"
+  loop: "{{ nginx_module_configs }}"
+  notify:
+    - reload nginx
+
+- name: Create links for modules-enabled
+  file:
+    state: link
+    src: "{{ nginx_conf_dir }}/modules-available/{{ item }}.conf"
+    dest: "{{ nginx_conf_dir }}/modules-enabled/{{ item }}.conf"
+  with_items: "{{ nginx_module_configs }}"
+  when: (item not in nginx_remove_modules) and (item not in nginx_disabled_modules)
+  ignore_errors: "{{ ansible_check_mode }}"
+  notify:
+    - reload nginx

--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -59,21 +59,14 @@
     - reload nginx
   when: nginx_stream_params or nginx_stream_configs
 
-- name: Create configuration for modules
-  template:
-    src: module.conf.j2
-    dest: "{{ nginx_conf_dir }}/modules-available/{{ item }}.conf"
-  loop: "{{ nginx_module_configs }}"
-  notify:
-    - reload nginx
-
 - name: Create links for modules-enabled
   file:
     state: link
-    src: "{{ nginx_conf_dir }}/modules-available/{{ item }}.conf"
+    src: "/urs/share/nginx/modules/{{ item }}.conf"
     dest: "{{ nginx_conf_dir }}/modules-enabled/{{ item }}.conf"
   with_items: "{{ nginx_module_configs }}"
   when: (item not in nginx_remove_modules) and (item not in nginx_disabled_modules)
   ignore_errors: "{{ ansible_check_mode }}"
   notify:
     - reload nginx
+  when: ansible_distribution == 'CentOS' or ansible_distribution == 'Red Hat Enterprise Linux'

--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -59,11 +59,23 @@
     - reload nginx
   when: nginx_stream_params or nginx_stream_configs
 
-- name: Create links for modules-enabled
+- name: Create configuration files in modules-available (only for nginx official repo or custom modules, Centos/RHEL/Debian/Ubuntu EPEL/APT repo packages have these config files already)
+  template:
+    src: module.conf.j2
+    dest: "{{ nginx_conf_dir }}/modules-available/{{ item }}.conf"
+  with_items: "{{ nginx_module_configs }}"
+  ignore_errors: "{{ ansible_check_mode }}"
+  notify:
+    - reload nginx
+  when:
+    - (item not in nginx_remove_modules) and (item not in nginx_disabled_modules)
+    - nginx_official_repo
+
+- name: Create links in modules-available to Centos/RHEL EPEL provided configuration files. Debian/Ubuntu APT provided packages already have these config files.
   file:
     state: link
     src: "/usr/share/nginx/modules/{{ item }}.conf"
-    dest: "{{ nginx_conf_dir }}/modules-enabled/{{ item }}.conf"
+    dest: "{{ nginx_conf_dir }}/modules-available/{{ item }}.conf"
   with_items: "{{ nginx_module_configs }}"
   ignore_errors: "{{ ansible_check_mode }}"
   notify:
@@ -71,5 +83,43 @@
   when:
     - (item not in nginx_remove_modules) and (item not in nginx_disabled_modules)
     - ansible_distribution == 'CentOS' or ansible_distribution == 'Red Hat Enterprise Linux'
-    - nginx_install_epel_repo
+    - not nginx_official_repo
+
+- name: Create links in our modules-available to Debian/Ubuntu APT provided config files.
+  file:
+    state: link
+    src: "/usr/share/nginx/modules-available/{{ item }}.conf"
+    dest: "{{ nginx_conf_dir }}/modules-available/{{ item }}.conf"
+  with_items: "{{ nginx_module_configs }}"
+  ignore_errors: "{{ ansible_check_mode }}"
+  notify:
+    - reload nginx
+  when:
+    - (item not in nginx_remove_modules) and (item not in nginx_disabled_modules)
+    - ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu'
+    - not nginx_official_repo
+
+- name: Move out of the way any existing "50-" style links in modules-available, only for Debian/Ubuntu APT provided packages
+  command: "mv {{ nginx_conf_dir }}/modules-enabled/50-{{ item }}.conf {{ nginx_conf_dir }}/modules-enabled/50-{{ item }}.conf.renamedasnowmanaged"
+  args:
+    removes: "{{ nginx_conf_dir }}/modules-enabled/50-{{ item }}.conf"
+  with_items: "{{ nginx_module_configs }}"
+  ignore_errors: "{{ ansible_check_mode }}"
+  notify:
+    - reload nginx
+  when:
+    - (item not in nginx_remove_modules) and (item not in nginx_disabled_modules)
+    - ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu'
+    - not nginx_official_repo
+
+- name: Create links in modules-enabled from modules-available
+  file:
+    state: link
+    src: "{{ nginx_conf_dir }}/modules-available/{{ item }}.conf"
+    dest: "{{ nginx_conf_dir }}/modules-enabled/{{ item }}.conf"
+  with_items: "{{ nginx_module_configs }}"
+  when: (item not in nginx_remove_modules) and (item not in nginx_disabled_modules)
+  ignore_errors: "{{ ansible_check_mode }}"
+  notify:
+    - reload nginx
 

--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -52,7 +52,7 @@
 
 - name: Create the configurations for independent config file
   template:
-    src: config.conf.j2
+    src: "{{ item.value.template | default('config.conf.j2') }}"
     dest: "{{ nginx_conf_dir }}/conf.d/{{ item.key }}.conf"
   with_dict: "{{ nginx_configs }}"
   notify:

--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -30,6 +30,7 @@
     dest: "{{ nginx_conf_dir }}/sites-enabled/{{ item.key }}.conf"
   with_dict: "{{ nginx_sites }}"
   when: (item.key not in nginx_remove_sites) and (item.key not in nginx_disabled_sites)
+  ignore_errors: "{{ ansible_check_mode }}"
   notify:
     - reload nginx
 

--- a/tasks/ensure-dirs.yml
+++ b/tasks/ensure-dirs.yml
@@ -1,11 +1,11 @@
 ---
 - name: Create the directories for site specific configurations
   file:
-    path: "{{nginx_conf_dir}}/{{ item }}"
+    path: "{{ nginx_conf_dir }}/{{ item }}"
     state: directory
     owner: "{{ nginx_conf_user }}"
     group: "{{ nginx_conf_group }}"
-    mode: "{{nginx_dir_perm}}"
+    mode: "{{ nginx_dir_perm }}"
   with_items:
     - "sites-available"
     - "sites-enabled"
@@ -20,6 +20,6 @@
   file:
     path: "{{ nginx_log_dir }}"
     state: directory
-    owner: "{{nginx_log_user}}"
-    group: "{{nginx_log_group}}"
-    mode: "{{nginx_log_perm}}"
+    owner: "{{ nginx_log_user }}"
+    group: "{{ nginx_log_group }}"
+    mode: "{{ nginx_log_perm }}"

--- a/tasks/installation.packages.yml
+++ b/tasks/installation.packages.yml
@@ -4,12 +4,10 @@
   when: nginx_is_el|bool and nginx_install_epel_repo|bool
 
 - name: Install the nginx packages from official repo for EL distributions
-  yum: name={{ item }} state=present enablerepo="nginx"
-  with_items: "{{ nginx_pkgs }}"
+  yum: name="{{ nginx_pkgs }}" state=present enablerepo="nginx"
   when: nginx_is_el|bool and nginx_official_repo
 
 - name: Install the nginx packages for all other distributions
-  package: name={{ item }} state=present
-  with_items: "{{ nginx_pkgs }}"
+  package: name="{{ nginx_pkgs }}" state=present
   environment: "{{ nginx_env }}"
   when: not nginx_is_el|bool or not nginx_official_repo

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,7 @@
 ---
 
-- include_vars: "{{ item }}"
+- name: include OS dependent vars
+  include_vars: "{{ item }}"
   with_first_found:
     - "../vars/{{ ansible_os_family }}.yml"
     - "../vars/empty.yml"
@@ -12,7 +13,7 @@
   tags: [packages, selinux, nginx]
 
 - include_tasks: nginx-official-repo.yml
-  when: nginx_official_repo == True
+  when: nginx_official_repo|bool
   tags: [packages, nginx]
 
 - include_tasks: installation.packages.yml
@@ -37,14 +38,14 @@
   tags: [configuration, nginx]
 
 - include_tasks: cloudflare_configuration.yml
-  when: nginx_set_real_ip_from_cloudflare == True
+  when: nginx_set_real_ip_from_cloudflare|bool
   tags: [configuration, nginx]
 
 - include_tasks: amplify.yml
-  when: nginx_amplify == true and (ansible_distribution in ['RedHat', 'CentOS', 'Debian', 'Amazon', 'Ubuntu'])
+  when: nginx_amplify|bool and (ansible_distribution in ['RedHat', 'CentOS', 'Debian', 'Amazon', 'Ubuntu'])
   tags: [amplify, nginx]
 
 - name: Start the nginx service
-  service: name={{ nginx_service_name }} state={{nginx_start_service | ternary('started', 'stopped')}} enabled={{nginx_start_at_boot}}
+  service: name={{ nginx_service_name }} state={{ nginx_start_service | ternary('started', 'stopped') }} enabled={{ nginx_start_at_boot }}
   when: nginx_installation_type in nginx_installation_types_using_service and nginx_daemon_mode == "on"
   tags: [service, nginx]

--- a/tasks/remove-defaults.yml
+++ b/tasks/remove-defaults.yml
@@ -1,14 +1,14 @@
 ---
 - name: Disable the default site
   file:
-    path: "{{nginx_conf_dir}}/sites-enabled/default"
+    path: "{{ nginx_conf_dir }}/sites-enabled/default"
     state: absent
   notify:
     - reload nginx
 
 - name: Disable the default site (on newer nginx versions)
   file:
-    path: "{{nginx_conf_dir}}/sites-enabled/default.conf"
+    path: "{{ nginx_conf_dir }}/sites-enabled/default.conf"
     state: absent
   notify:
     - reload nginx
@@ -17,7 +17,7 @@
 
 - name: Remove the default configuration
   file:
-    path: "{{nginx_conf_dir}}/conf.d/default.conf"
+    path: "{{ nginx_conf_dir }}/conf.d/default.conf"
     state: absent
   when: >
     'default' not in nginx_configs.keys()

--- a/tasks/remove-defaults.yml
+++ b/tasks/remove-defaults.yml
@@ -6,6 +6,15 @@
   notify:
     - reload nginx
 
+- name: Disable the default site (on newer nginx versions)
+  file:
+    path: "{{nginx_conf_dir}}/sites-enabled/default.conf"
+    state: absent
+  notify:
+    - reload nginx
+  when: >
+     'default' not in nginx_sites.keys()
+
 - name: Remove the default configuration
   file:
     path: "{{nginx_conf_dir}}/conf.d/default.conf"

--- a/tasks/remove-extras.yml
+++ b/tasks/remove-extras.yml
@@ -1,12 +1,12 @@
 ---
 - name: Find enabled sites
-  shell: ls -1 {{nginx_conf_dir}}/sites-enabled || true
+  shell: ls -1 {{ nginx_conf_dir }}/sites-enabled || true
   register: enabled_sites
   changed_when: False
 
 - name: Disable unmanaged sites
   file:
-    path: "{{nginx_conf_dir}}/sites-enabled/{{ item }}"
+    path: "{{ nginx_conf_dir }}/sites-enabled/{{ item }}"
     state: absent
   with_items: "{{ enabled_sites.stdout_lines | default([]) }}"
   # 'item.conf' => 'item'
@@ -15,13 +15,13 @@
     - reload nginx
 
 - name: Find config files
-  shell: find {{nginx_conf_dir}}/conf.d -maxdepth 1 -type f -name '*.conf' -exec basename {} \;
+  shell: find {{ nginx_conf_dir }}/conf.d -maxdepth 1 -type f -name '*.conf' -exec basename {} \;
   register: config_files
   changed_when: False
 
 - name: Remove unmanaged config files
   file:
-    name: "{{nginx_conf_dir}}/conf.d/{{ item }}"
+    name: "{{ nginx_conf_dir }}/conf.d/{{ item }}"
     state: absent
   with_items: "{{ config_files.stdout_lines | default([]) }}"
   # 'item.conf' => 'item'

--- a/tasks/remove-unwanted.yml
+++ b/tasks/remove-unwanted.yml
@@ -1,7 +1,7 @@
 ---
 - name: Remove unwanted sites
   file:
-    path: "{{nginx_conf_dir}}/{{ item[0] }}/{{ item[1] }}.conf"
+    path: "{{ nginx_conf_dir }}/{{ item[0] }}/{{ item[1] }}.conf"
     state: absent
   with_nested:
     - ['sites-enabled', 'sites-available']
@@ -11,7 +11,7 @@
 
 - name: Remove unwanted conf
   file:
-    path: "{{nginx_conf_dir}}/conf.d/{{ item }}.conf"
+    path: "{{ nginx_conf_dir }}/conf.d/{{ item }}.conf"
     state: absent
   with_items: "{{ nginx_remove_configs }}"
   notify:
@@ -27,7 +27,7 @@
 
 - name: Remove unwanted auth_basic_files
   file:
-    path: "{{nginx_conf_dir}}/auth_basic/{{ item }}"
+    path: "{{ nginx_conf_dir }}/auth_basic/{{ item }}"
     state: absent
   with_items: "{{ nginx_remove_auth_basic_files }}"
   notify:

--- a/tasks/selinux.yml
+++ b/tasks/selinux.yml
@@ -1,17 +1,7 @@
 ---
 - name: Install the selinux python module
-  package: name={{ item }} state=present
-  with_items:
-    - libselinux-python
-    - libsemanage-python
-  when: ansible_os_family == "RedHat"
-
-- name: Install the selinux python module
-  package: name={{ item }} state=present
-  with_items:
-    - python-selinux
-    - python-semanage
-  when: ansible_os_family == "Debian"
+  package: name={{ nginx_python_selinux_pkgs | default(omit)}} state=present
+  when: ansible_os_family == "RedHat" or ansible_os_family == "Debian"
 
 - name: Set SELinux boolean to allow nginx to set rlimit
   seboolean: name=httpd_setrlimit state=yes persistent=yes

--- a/tasks/selinux.yml
+++ b/tasks/selinux.yml
@@ -1,6 +1,6 @@
 ---
 - name: Install the selinux python module
-  package: name={{ nginx_python_selinux_pkgs | default(omit)}} state=present
+  package: name={{ nginx_python_selinux_pkgs | default(omit) }} state=present
   when: ansible_os_family == "RedHat" or ansible_os_family == "Debian"
 
 - name: Set SELinux boolean to allow nginx to set rlimit

--- a/templates/module.conf.j2
+++ b/templates/module.conf.j2
@@ -1,0 +1,3 @@
+#{{ ansible_managed }}
+
+load_module "modules/{{ item }}.so";

--- a/templates/module.conf.j2
+++ b/templates/module.conf.j2
@@ -1,3 +1,3 @@
 #{{ ansible_managed }}
 
-load_module "modules/{{ item }}.so";
+load_module "{{ nginx_modules_location }}/{{ item }}.so";

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,2 +1,6 @@
 ---
 nginx_user: www-data
+
+nginx_python_selinux_pkgs:
+  - python-selinux
+  - python-semanage

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -4,3 +4,5 @@ nginx_user: www-data
 nginx_python_selinux_pkgs:
   - python-selinux
   - python-semanage
+
+nginx_modules_location: /usr/lib/nginx/modules

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,0 +1,4 @@
+---
+nginx_python_selinux_pkgs:
+  - libselinux-python
+  - libsemanage-python

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -2,3 +2,6 @@
 nginx_python_selinux_pkgs:
   - libselinux-python
   - libsemanage-python
+
+nginx_modules_location: /usr/lib64/nginx/modules
+

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -13,3 +13,5 @@ nginx_http_default_params:
   - server_tokens off
   - access_log "{{nginx_log_dir}}/access.log"
   - error_log "{{nginx_log_dir}}/error.log" {{nginx_error_log_level}}
+
+nginx_python_selinux_pkgs: []


### PR DESCRIPTION
This is safe, since the submodule in `hs-ansible-scripts` is pinned to an older version.
And this enables us to update it to avoid Ansible deprecation warnings.